### PR TITLE
Update WebSocket server port on slave service

### DIFF
--- a/src/services/Slave/index.js
+++ b/src/services/Slave/index.js
@@ -15,7 +15,7 @@ class SlaveService extends EventEmitter {
 
   connect() {
     const { hostname } = window.location;
-    const port = window.location.protocol === 'https:' ? 443 : 3004;
+    const port = window.location.protocol === 'http:' ? 80 : 3004;
     this.socket = new WebSocket(`ws://${hostname}:${port}/ws`);
     this.socket.addEventListener('message', this.handleMessage.bind(this));
     const onOpen = () => {


### PR DESCRIPTION
Since we aren't running a secure websocket server (wss) the verified
current protocol and its port should be 'http' and 80, respectively.